### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,7 +1,7 @@
 ---
 name: Roadmap Item
 about: This is standard Parity Roadmap item description
-title: Feature Title
+title: Milestone Title
 labels: ''
 assignees: ''
 
@@ -25,6 +25,7 @@ Describe why this milestone is relevant and what goals it accomplishes.>
 
 # The Plan
 \<What steps are needed to realise the vision?> 
+_Use Github Tasklist in order to create issues related to this milestone. Update the Tasklist once in a while if new issues arise by time._
 
 # Open Questions
 _If you want to help us out and contribute to this issue, in this section you can find open questions and tasks where we would appreciate any input._
@@ -32,18 +33,3 @@ _If you want to help us out and contribute to this issue, in this section you ca
 \<Leave open questions or tasks where the community could help>
 
 ---
-
-✄ ---------------------------------------------------------------------------
-
-**Remove this section**
-
-3. If you don't have so far, create your own project where related sub-tasks will be assigned to it. 
-4. Create in your project a new field called "Milestone in Parity Roadmap".
-5. Assign this issue to your project and link every other related issue (sub-tasks) of your project that is part of the realisation of this milestone to the appropriate option on your new field.
-6. Create a new view on your project and set a filter for your new field where you can find all related tasks to your milestone.
-7. Paste the link of your new view in the space holder below.
-
-✄ ---------------------------------------------------------------------------
-
-Here you can find the board with specific sub-tasks to this milestone:
-\<Link to your project's view>


### PR DESCRIPTION
As GH now provides a tasklist which creates a relation between tasks and subtasks, we can get rid off the workaround that we implemented back then